### PR TITLE
Spawn captain's favor above ground always

### DIFF
--- a/Items/Void/CaptainsFavor.cs
+++ b/Items/Void/CaptainsFavor.cs
@@ -341,7 +341,7 @@ namespace Hex3Mod.Items
                             {
                                 pickerOptions = PickupPickerController.GenerateOptionsFromArray(generatedDrops),
                                 prefabOverride = potentialPrefab,
-                                position = self.dropTransform.position,
+                                position = self.dropTransform.position + Vector3.up * 1.5f,
                                 rotation = Quaternion.identity,
                                 pickupIndex = PickupCatalog.FindPickupIndex(firstDropTier)
                             }, 


### PR DESCRIPTION
Fix part of #18. Spawns the void potential 1.5 units above the chest, which is what chests normally do for items.